### PR TITLE
Add FastAPI backend for OpenAI Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # kosmos2
-Kosmos2
+
+This project provides a simple FastAPI backend that uses OpenAI's Whisper API
+for speech-to-text. Send an audio file to `/transcribe` and receive the text
+transcription.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+   The `openai` package is not required because the API is called directly.
+
+2. Set the API key environment variable:
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+
+3. Run the server:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+4. Send a POST request with an audio file to `http://localhost:8000/transcribe`.
+
+## Running tests
+
+Tests require `pytest` and `fastapi`. Execute:
+
+```bash
+pytest
+```
+
+They patch the Whisper call to avoid real network usage.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,65 @@
+import os
+import json
+import uuid
+import mimetypes
+import urllib.request
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+
+app = FastAPI()
+
+OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
+
+
+def call_whisper(file_bytes: bytes, filename: str) -> str:
+    """Send audio to OpenAI Whisper API and return the transcript."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    boundary = uuid.uuid4().hex
+    fields = {
+        "model": "whisper-1",
+        "response_format": "json",
+    }
+
+    parts = []
+    for name, value in fields.items():
+        parts.append(f"--{boundary}")
+        parts.append(f'Content-Disposition: form-data; name="{name}"')
+        parts.append("")
+        parts.append(value)
+
+    mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    parts.append(f"--{boundary}")
+    parts.append(
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"'
+    )
+    parts.append(f"Content-Type: {mimetype}")
+    parts.append("")
+
+    body_pre = "\r\n".join(parts).encode() + b"\r\n"
+    body_post = f"\r\n--{boundary}--\r\n".encode()
+    body = body_pre + file_bytes + body_post
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+
+    req = urllib.request.Request(OPENAI_URL, data=body, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        data = json.load(resp)
+    return data.get("text", "")
+
+
+@app.post("/transcribe")
+async def transcribe(file: UploadFile = File(...)):
+    """Receive an audio file and return the transcription."""
+    data = await file.read()
+    await file.close()
+    try:
+        text = call_whisper(data, file.filename)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"text": text}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,17 @@
+import io
+from fastapi.testclient import TestClient
+import main
+
+
+def test_transcribe(monkeypatch):
+    client = TestClient(main.app)
+
+    def fake_call_whisper(data, filename):
+        return "transcribed"
+
+    monkeypatch.setattr(main, "call_whisper", fake_call_whisper)
+
+    files = {"file": ("test.mp3", io.BytesIO(b"123"), "audio/mpeg")}
+    response = client.post("/transcribe", files=files)
+    assert response.status_code == 200
+    assert response.json() == {"text": "transcribed"}


### PR DESCRIPTION
## Summary
- implement `main.py` with a FastAPI app calling OpenAI Whisper via HTTP
- document usage and testing in README
- add unit test that patches the Whisper call

## Testing
- `python3 -m py_compile main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6844653e67a8832aa2a6c74732edabd1