### PR TITLE
Add simple front‑end for transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ transcription.
    uvicorn main:app --reload
    ```
 
-4. Send a POST request with an audio file to `http://localhost:8000/transcribe`.
+4. Visit `http://localhost:8000/` in your browser to use a simple upload page.
+   You can also send a POST request with an audio file directly to
+   `http://localhost:8000/transcribe`.
 
 ## Running tests
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Audio Transcription</title>
+</head>
+<body>
+  <h1>Audio Transcription</h1>
+  <input type="file" id="file-input" />
+  <button id="submit">Transcribe</button>
+  <pre id="result"></pre>
+  <script>
+    const btn = document.getElementById('submit');
+    btn.addEventListener('click', async () => {
+      const input = document.getElementById('file-input');
+      if (!input.files.length) {
+        alert('Select a file');
+        return;
+      }
+      const file = input.files[0];
+      const formData = new FormData();
+      formData.append('file', file);
+      const response = await fetch('/transcribe', { method: 'POST', body: formData });
+      if (response.ok) {
+        const data = await response.json();
+        document.getElementById('result').textContent = data.text;
+      } else {
+        document.getElementById('result').textContent = 'Error: ' + response.status;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -5,8 +5,17 @@ import mimetypes
 import urllib.request
 
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import HTMLResponse
 
 app = FastAPI()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    """Serve a minimal HTML page for uploading audio."""
+    path = os.path.join(os.path.dirname(__file__), "frontend", "index.html")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
 
 OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
 


### PR DESCRIPTION
## Summary
- serve a minimal HTML upload page on `/`
- provide frontend HTML and update README with instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6844662f4168832abd33b6b2041d5d88