### PR TITLE
Add run-from-main support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ transcription.
    ```bash
    uvicorn main:app --reload
    ```
+   You can also simply execute the `main.py` file which starts Uvicorn
+   programmatically:
+   ```bash
+   python main.py
+   ```
 
 4. Visit `http://localhost:8000/` in your browser to use a simple upload page.
    You can also send a POST request with an audio file directly to

--- a/main.py
+++ b/main.py
@@ -7,6 +7,11 @@ import urllib.request
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import HTMLResponse
 
+try:
+    import uvicorn
+except ImportError:  # pragma: no cover - uvicorn is only needed to run the server
+    uvicorn = None
+
 app = FastAPI()
 
 
@@ -72,3 +77,14 @@ async def transcribe(file: UploadFile = File(...)):
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
     return {"text": text}
+
+
+if __name__ == "__main__":  # pragma: no cover - server start
+    if uvicorn is None:
+        raise RuntimeError("uvicorn must be installed to run the server")
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8000")),
+        reload=os.getenv("RELOAD", "0") == "1",
+    )


### PR DESCRIPTION
## Summary
- allow running the FastAPI app directly by starting uvicorn in `main.py`
- document running `python main.py` in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684468449584832aa836b039d8028f0e