### PR TITLE
Implement single-button test for Test10.mp3

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,20 +6,22 @@
 </head>
 <body>
   <h1>Audio Transcription</h1>
-  <input type="file" id="file-input" />
-  <button id="submit">Transcribe</button>
+  <button id="submit">Transcribe Test10.mp3</button>
   <pre id="result"></pre>
   <script>
     const btn = document.getElementById('submit');
     btn.addEventListener('click', async () => {
-      const input = document.getElementById('file-input');
-      if (!input.files.length) {
-        alert('Select a file');
+      // Fetch the local Test10.mp3 file from the backend
+      const audioResp = await fetch('/Test10.mp3');
+      if (!audioResp.ok) {
+        document.getElementById('result').textContent = 'Error fetching audio file';
         return;
       }
-      const file = input.files[0];
+
+      const blob = await audioResp.blob();
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append('file', blob, 'Test10.mp3');
+
       const response = await fetch('/transcribe', { method: 'POST', body: formData });
       if (response.ok) {
         const data = await response.json();

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import mimetypes
 import urllib.request
 
 from fastapi import FastAPI, UploadFile, File, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, FileResponse
 
 try:
     import uvicorn
@@ -21,6 +21,13 @@ async def index():
     path = os.path.join(os.path.dirname(__file__), "frontend", "index.html")
     with open(path, "r", encoding="utf-8") as fh:
         return fh.read()
+
+
+@app.get("/Test10.mp3")
+async def serve_test_audio():
+    """Return the bundled Test10.mp3 file for testing."""
+    path = os.path.join(os.path.dirname(__file__), "Test10.mp3")
+    return FileResponse(path, media_type="audio/mpeg")
 
 OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
 


### PR DESCRIPTION
## Summary
- serve bundled Test10.mp3 via new `/Test10.mp3` route
- simplify front-end to a single button that fetches Test10.mp3 and posts it to `/transcribe`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684469eba1a4832ab55b9a2e17bcf6ba