### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+python-multipart
+httpx
+pytest


### PR DESCRIPTION
## Summary
- add dependencies list for easy setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68446a03da68832ab514b2b88e385b66