### PR TITLE
Support large file uploads via client-side chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ transcription.
    ```
 
 4. Visit `http://localhost:8000/` in your browser to use the upload page.
-   Select an MP3 or M4A file, watch the progress bar as it uploads, and
-   download the resulting transcription when it completes. You can also
-   send a POST request with an audio file directly to
-   `http://localhost:8000/transcribe`.
+   Select an MP3 or M4A file. Large uploads are automatically split into
+   ten minute chunks so they can be processed by Whisper. The progress bar
+   updates after each chunk is transcribed and the text appears
+   incrementally. You can also send a POST request with an audio file
+   directly to `http://localhost:8000/transcribe`.
 
 ## Running tests
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,41 +33,62 @@
     const resultPre = document.getElementById('result');
     const downloadLink = document.getElementById('download');
 
-    form.addEventListener('submit', function(e) {
+    async function getChunkSize(file) {
+      const CHUNK_SECONDS = 600; // 10 minutes
+      return new Promise((resolve) => {
+        const audio = new Audio();
+        audio.preload = 'metadata';
+        audio.src = URL.createObjectURL(file);
+        audio.onloadedmetadata = () => {
+          const bytesPerSecond = file.size / audio.duration;
+          URL.revokeObjectURL(audio.src);
+          resolve(bytesPerSecond * CHUNK_SECONDS);
+        };
+        audio.onerror = () => {
+          URL.revokeObjectURL(audio.src);
+          // Fallback to 24MB if duration can't be determined
+          resolve(24 * 1024 * 1024);
+        };
+      });
+    }
+
+    form.addEventListener('submit', async function(e) {
       e.preventDefault();
       const file = fileInput.files[0];
       if (!file) return;
 
-      const formData = new FormData();
-      formData.append('file', file, file.name);
-
-      const xhr = new XMLHttpRequest();
-      xhr.open('POST', '/transcribe');
-
-      xhr.upload.onprogress = function(event) {
-        if (event.lengthComputable) {
-          const percent = (event.loaded / event.total) * 100;
-          progressBar.style.width = percent + '%';
-        }
-      };
-
-      xhr.onload = function() {
-        if (xhr.status === 200) {
-          const data = JSON.parse(xhr.responseText);
-          resultPre.textContent = data.text;
-          const blob = new Blob([data.text], {type: 'text/plain'});
-          downloadLink.href = URL.createObjectURL(blob);
-          downloadLink.download = (file.name.split('.').slice(0, -1).join('.') || 'transcription') + '.txt';
-          downloadLink.style.display = 'inline-block';
-        } else {
-          resultPre.textContent = 'Error: ' + xhr.status;
-        }
-      };
-
       progressBar.style.width = '0%';
       resultPre.textContent = '';
       downloadLink.style.display = 'none';
-      xhr.send(formData);
+
+      const chunkSize = await getChunkSize(file);
+      const totalChunks = Math.ceil(file.size / chunkSize);
+      let resultText = '';
+
+      for (let i = 0; i < totalChunks; i++) {
+        const start = i * chunkSize;
+        const end = Math.min(start + chunkSize, file.size);
+        const chunk = file.slice(start, end);
+
+        const formData = new FormData();
+        formData.append('file', chunk, file.name);
+
+        const response = await fetch('/transcribe', { method: 'POST', body: formData });
+        if (!response.ok) {
+          resultPre.textContent = 'Error: ' + response.status;
+          return;
+        }
+
+        const data = await response.json();
+        resultText += data.text + '\n';
+        resultPre.textContent = resultText;
+        progressBar.style.width = ((i + 1) / totalChunks * 100) + '%';
+      }
+
+      const blob = new Blob([resultText], {type: 'text/plain'});
+      downloadLink.href = URL.createObjectURL(blob);
+      downloadLink.download = (file.name.split('.').slice(0, -1).join('.') || 'transcription') + '.txt';
+      downloadLink.style.display = 'inline-block';
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- handle large uploads in `index.html` by slicing audio into ~10 minute chunks
- show progress after each chunk and allow incremental transcription display
- document chunking behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844711cbae8832a9fcfb26ec33c4d47