### PR TITLE
Add language selection, sentence formatting, progress UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,11 +18,18 @@
     <h1>Audio Transcription</h1>
     <form id="uploadForm">
       <input type="file" id="fileInput" accept="audio/mpeg,audio/mp4" required>
+      <select id="language">
+        <option value="">Auto Detect</option>
+        <option value="en">English</option>
+        <option value="es">Spanish</option>
+        <option value="fr">French</option>
+      </select>
       <button type="submit">Transcribe</button>
     </form>
     <div class="progress" id="progress-container">
       <div class="progress-bar" id="progress-bar"></div>
     </div>
+    <div id="estimate"></div>
     <pre id="result"></pre>
     <a id="download" href="#">Download Transcription</a>
   </div>
@@ -32,6 +39,8 @@
     const progressBar = document.getElementById('progress-bar');
     const resultPre = document.getElementById('result');
     const downloadLink = document.getElementById('download');
+    const languageSelect = document.getElementById('language');
+    const estimateDiv = document.getElementById('estimate');
 
     async function getChunkSize(file) {
       const CHUNK_SECONDS = 600; // 10 minutes
@@ -57,12 +66,16 @@
       const file = fileInput.files[0];
       if (!file) return;
 
-      progressBar.style.width = '0%';
+      progressBar.style.width = '1%';
       resultPre.textContent = '';
       downloadLink.style.display = 'none';
+      estimateDiv.textContent = '';
 
       const chunkSize = await getChunkSize(file);
       const totalChunks = Math.ceil(file.size / chunkSize);
+      const lang = languageSelect.value;
+      const estimateSeconds = totalChunks * 15;
+      estimateDiv.textContent = 'Estimated time: ~' + estimateSeconds + ' seconds';
       let resultText = '';
 
       for (let i = 0; i < totalChunks; i++) {
@@ -73,7 +86,8 @@
         const formData = new FormData();
         formData.append('file', chunk, file.name);
 
-        const response = await fetch('/transcribe', { method: 'POST', body: formData });
+        const url = lang ? '/transcribe?language=' + encodeURIComponent(lang) : '/transcribe';
+        const response = await fetch(url, { method: 'POST', body: formData });
         if (!response.ok) {
           resultPre.textContent = 'Error: ' + response.status;
           return;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ import main
 def test_transcribe(monkeypatch):
     client = TestClient(main.app)
 
-    def fake_call_whisper(data, filename):
+    def fake_call_whisper(data, filename, language=None):
         return "transcribed"
 
     monkeypatch.setattr(main, "call_whisper", fake_call_whisper)
@@ -21,3 +21,21 @@ def test_transcribe(monkeypatch):
     response = client.post("/transcribe", files=files)
     assert response.status_code == 200
     assert response.json() == {"text": "transcribed"}
+
+
+def test_transcribe_language(monkeypatch):
+    client = TestClient(main.app)
+
+    captured = {}
+
+    def fake_call_whisper(data, filename, language=None):
+        captured['lang'] = language
+        return "words"
+
+    monkeypatch.setattr(main, "call_whisper", fake_call_whisper)
+
+    files = {"file": ("test.mp3", io.BytesIO(b"123"), "audio/mpeg")}
+    response = client.post("/transcribe?language=en", files=files)
+    assert response.status_code == 200
+    assert response.json() == {"text": "words"}
+    assert captured['lang'] == 'en'


### PR DESCRIPTION
## Summary
- support optional `language` when calling Whisper
- format returned text with newlines after sentences
- add language selector and time estimate in frontend
- show progress bar immediately on start
- update tests for new parameter and add coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684477560d10832a894b7d30275f6395