### PR TITLE
Add login flow and new languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ transcription.
    python main.py
    ```
 
-4. Visit `http://localhost:8000/` in your browser to use the upload page.
-   Select an MP3 or M4A file. Large uploads are automatically split into
-   ten minute chunks so they can be processed by Whisper. The progress bar
-   updates after each chunk is transcribed and the text appears
-   incrementally. You can also send a POST request with an audio file
-   directly to `http://localhost:8000/transcribe`.
+4. Open `http://localhost:8000/login` in your browser and log in with the
+   username **kosmos** and password **kosmos**. After authenticating you will
+   be redirected to `http://localhost:8000/` where you can upload an MP3 or
+   M4A file. Large uploads are automatically split into ten minute chunks so
+   they can be processed by Whisper. The progress bar updates after each
+   chunk is transcribed and the text appears incrementally. You can also send
+   a POST request with an audio file directly to
+   `http://localhost:8000/transcribe`.
 
 ## Running tests
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,9 @@
         <option value="en">English</option>
         <option value="es">Spanish</option>
         <option value="fr">French</option>
+        <option value="ru">Russian</option>
+        <option value="az">Azerbaijani</option>
+        <option value="zh">Chinese</option>
       </select>
       <button type="submit">Transcribe</button>
     </form>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
+    .container { max-width: 300px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    h1 { text-align: center; }
+    input { display: block; width: 100%; margin-bottom: 10px; padding: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Login</h1>
+    <form method="post" action="/login">
+      <input type="text" name="username" placeholder="Username" required>
+      <input type="password" name="password" placeholder="Password" required>
+      <button type="submit">Log In</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple login page and authentication endpoints
- protect the root page via a cookie-based check
- document the login step in the README
- expand language options to include Russian, Azerbaijani and Chinese

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684479af0594832a951bc245a1c36f41