### PR TITLE
Display remaining minutes on transcription page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,7 @@
       <div class="progress-bar" id="progress-bar"></div>
     </div>
     <div id="estimate"></div>
+    <div id="remaining"></div>
     <pre id="result"></pre>
     <a id="download" href="#">Download Transcription</a>
   </div>
@@ -44,6 +45,17 @@
     const downloadLink = document.getElementById('download');
     const languageSelect = document.getElementById('language');
     const estimateDiv = document.getElementById('estimate');
+    const remainingDiv = document.getElementById('remaining');
+
+    async function updateRemaining() {
+      const resp = await fetch('/remaining');
+      if (resp.ok) {
+        const data = await resp.json();
+        remainingDiv.textContent = 'Minutes remaining: ' + data.minutes.toFixed(2);
+      }
+    }
+
+    updateRemaining();
 
     async function getChunkSize(file) {
       const CHUNK_SECONDS = 600; // 10 minutes
@@ -100,6 +112,7 @@
         resultText += data.text + '\n';
         resultPre.textContent = resultText;
         progressBar.style.width = ((i + 1) / totalChunks * 100) + '%';
+        await updateRemaining();
       }
 
       const blob = new Blob([resultText], {type: 'text/plain'});

--- a/main.py
+++ b/main.py
@@ -73,6 +73,20 @@ async def logout():
     response.delete_cookie("username")
     return response
 
+
+@app.get("/remaining")
+async def remaining(request: Request):
+    """Return minutes remaining for the authenticated user."""
+    if request.cookies.get("auth") != "1":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    username = request.cookies.get("username")
+    if not username:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    user = db.get_user(username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return {"minutes": user["minutes_remaining"]}
+
 OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,3 +56,11 @@ def test_transcribe_language(monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"text": "words"}
     assert captured['lang'] == 'en'
+
+
+def test_remaining_endpoint():
+    client = client_with_auth()
+    db.set_limit("tester", 5)
+    response = client.get("/remaining")
+    assert response.status_code == 200
+    assert response.json() == {"minutes": 5}


### PR DESCRIPTION
## Summary
- show minutes remaining in the transcription UI
- add `/remaining` API endpoint for retrieving a user's remaining minutes
- exercise the new endpoint in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447ee7fde4832ab305e130b71d103b