### PR TITLE
Add bilingual interface with language switcher

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,29 +5,32 @@
   <title>Audio Transcription</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .container { max-width: 600px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: relative; }
     h1 { text-align: center; }
     .progress { width: 100%; height: 20px; background-color: #eee; border-radius: 10px; overflow: hidden; margin-top: 10px; }
     .progress-bar { height: 100%; width: 0%; background-color: #4caf50; transition: width 0.2s; }
     pre { background: #f8f8f8; padding: 10px; border: 1px solid #ddd; border-radius: 4px; white-space: pre-wrap; }
     #download { display: none; margin-top: 10px; }
+    .lang-switch { position: absolute; top: 10px; right: 10px; }
+    .lang-switch a { color: lightblue; margin-left: 5px; text-decoration: none; }
   </style>
 </head>
 <body>
+  <div class="lang-switch"><a href="#" data-lang="en" class="lang-link">EN</a> | <a href="#" data-lang="ru" class="lang-link">RU</a></div>
   <div class="container">
-    <h1>Audio Transcription</h1>
+    <h1 id="main-heading">Audio Transcription</h1>
     <form id="uploadForm">
       <input type="file" id="fileInput" accept="audio/mpeg,audio/mp4" required>
       <select id="language">
-        <option value="">Auto Detect</option>
-        <option value="en">English</option>
-        <option value="es">Spanish</option>
-        <option value="fr">French</option>
-        <option value="ru">Russian</option>
-        <option value="az">Azerbaijani</option>
-        <option value="zh">Chinese</option>
+        <option id="opt-auto" value="">Auto Detect</option>
+        <option id="opt-en" value="en">English</option>
+        <option id="opt-es" value="es">Spanish</option>
+        <option id="opt-fr" value="fr">French</option>
+        <option id="opt-ru" value="ru">Russian</option>
+        <option id="opt-az" value="az">Azerbaijani</option>
+        <option id="opt-zh" value="zh">Chinese</option>
       </select>
-      <button type="submit">Transcribe</button>
+      <button id="transcribe-btn" type="submit">Transcribe</button>
     </form>
     <div class="progress" id="progress-container">
       <div class="progress-bar" id="progress-bar"></div>
@@ -46,16 +49,81 @@
     const languageSelect = document.getElementById('language');
     const estimateDiv = document.getElementById('estimate');
     const remainingDiv = document.getElementById('remaining');
+    const langLinks = document.querySelectorAll('.lang-link');
+
+    const translations = {
+      en: {
+        title: 'Audio Transcription',
+        heading: 'Audio Transcription',
+        auto: 'Auto Detect',
+        en: 'English',
+        es: 'Spanish',
+        fr: 'French',
+        ru: 'Russian',
+        az: 'Azerbaijani',
+        zh: 'Chinese',
+        transcribe: 'Transcribe',
+        minutes: 'Minutes remaining: ',
+        estimate: 'Estimated time: ~',
+        seconds: ' seconds',
+        error: 'Error: ',
+        download: 'Download Transcription'
+      },
+      ru: {
+        title: 'Расшифровка аудио',
+        heading: 'Расшифровка аудио',
+        auto: 'Автоопределение',
+        en: 'Английский',
+        es: 'Испанский',
+        fr: 'Французский',
+        ru: 'Русский',
+        az: 'Азербайджанский',
+        zh: 'Китайский',
+        transcribe: 'Распознать',
+        minutes: 'Осталось минут: ',
+        estimate: 'Оценочное время: ~',
+        seconds: ' секунд',
+        error: 'Ошибка: ',
+        download: 'Скачать транскрипт'
+      }
+    };
+
+    let currentLang = localStorage.getItem('lang') || 'en';
+
+    function applyLang(lang) {
+      currentLang = lang;
+      localStorage.setItem('lang', lang);
+      const t = translations[lang];
+      document.documentElement.lang = lang;
+      document.title = t.title;
+      document.getElementById('main-heading').textContent = t.heading;
+      document.getElementById('opt-auto').textContent = t.auto;
+      document.getElementById('opt-en').textContent = t.en;
+      document.getElementById('opt-es').textContent = t.es;
+      document.getElementById('opt-fr').textContent = t.fr;
+      document.getElementById('opt-ru').textContent = t.ru;
+      document.getElementById('opt-az').textContent = t.az;
+      document.getElementById('opt-zh').textContent = t.zh;
+      document.getElementById('transcribe-btn').textContent = t.transcribe;
+      downloadLink.textContent = t.download;
+      updateRemaining();
+    }
+
+    langLinks.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        applyLang(link.dataset.lang);
+      });
+    });
+    applyLang(currentLang);
 
     async function updateRemaining() {
       const resp = await fetch('/remaining');
       if (resp.ok) {
         const data = await resp.json();
-        remainingDiv.textContent = 'Minutes remaining: ' + data.minutes.toFixed(2);
+        remainingDiv.textContent = translations[currentLang].minutes + data.minutes.toFixed(2);
       }
     }
-
-    updateRemaining();
 
     async function getChunkSize(file) {
       const CHUNK_SECONDS = 600; // 10 minutes
@@ -90,7 +158,7 @@
       const totalChunks = Math.ceil(file.size / chunkSize);
       const lang = languageSelect.value;
       const estimateSeconds = totalChunks * 15;
-      estimateDiv.textContent = 'Estimated time: ~' + estimateSeconds + ' seconds';
+      estimateDiv.textContent = translations[currentLang].estimate + estimateSeconds + translations[currentLang].seconds;
       let resultText = '';
 
       for (let i = 0; i < totalChunks; i++) {
@@ -104,7 +172,7 @@
         const url = lang ? '/transcribe?language=' + encodeURIComponent(lang) : '/transcribe';
         const response = await fetch(url, { method: 'POST', body: formData });
         if (!response.ok) {
-          resultPre.textContent = 'Error: ' + response.status;
+          resultPre.textContent = translations[currentLang].error + response.status;
           return;
         }
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -5,7 +5,7 @@
   <title>Login</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 40px; background-color: #f5f5f5; }
-    .container { max-width: 300px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .container { max-width: 300px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: relative; }
     h1 { text-align: center; }
     input {
       display: block;
@@ -20,17 +20,65 @@
       text-align: center;
       margin-top: 10px;
     }
+    .lang-switch { position: absolute; top: 10px; right: 10px; }
+    .lang-switch a { color: lightblue; margin-left: 5px; text-decoration: none; }
   </style>
 </head>
 <body>
+  <div class="lang-switch"><a href="#" data-lang="en" class="lang-link">EN</a> | <a href="#" data-lang="ru" class="lang-link">RU</a></div>
   <div class="container">
-    <h1>Login</h1>
+    <h1 id="login-heading">Login</h1>
     <form method="post" action="/login">
-      <input type="text" name="username" placeholder="Username" required>
-      <input type="password" name="password" placeholder="Password" required>
-      <button type="submit">Log In</button>
+      <input id="username-input" type="text" name="username" placeholder="Username" required>
+      <input id="password-input" type="password" name="password" placeholder="Password" required>
+      <button id="login-button" type="submit">Log In</button>
     </form>
   </div>
-  <p class="footer">Created by Konstantin Nasonov, please write to @k_nasonov for any questions</p>
+  <p class="footer" id="login-footer">Created by Konstantin Nasonov, please write to @k_nasonov for any questions</p>
+  <script>
+    const langLinks = document.querySelectorAll('.lang-link');
+    const translations = {
+      en: {
+        title: 'Login',
+        login: 'Login',
+        username: 'Username',
+        password: 'Password',
+        button: 'Log In',
+        footer: 'Created by Konstantin Nasonov, please write to @k_nasonov for any questions'
+      },
+      ru: {
+        title: 'Вход',
+        login: 'Вход',
+        username: 'Имя пользователя',
+        password: 'Пароль',
+        button: 'Войти',
+        footer: 'Создано Константином Насоновым, вопросы направляйте @k_nasonov'
+      }
+    };
+
+    let currentLang = localStorage.getItem('lang') || 'en';
+
+    function applyLang(lang) {
+      currentLang = lang;
+      localStorage.setItem('lang', lang);
+      const t = translations[lang];
+      document.documentElement.lang = lang;
+      document.title = t.title;
+      document.getElementById('login-heading').textContent = t.login;
+      document.getElementById('username-input').placeholder = t.username;
+      document.getElementById('password-input').placeholder = t.password;
+      document.getElementById('login-button').textContent = t.button;
+      document.getElementById('login-footer').textContent = t.footer;
+    }
+
+    langLinks.forEach(link => {
+      link.addEventListener('click', (e) => {
+        e.preventDefault();
+        applyLang(link.dataset.lang);
+      });
+    });
+
+    applyLang(currentLang);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add RU/EN switch links with styling
- translate index.html and login.html via JavaScript dictionaries
- store chosen language in localStorage and apply immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845622f7294832a9711b85c0c8fad6b