### PR TITLE
Fix m4a MIME handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,9 @@ import math
 import subprocess
 import tempfile
 
+# Ensure .m4a files are recognised with a suitable MIME type
+mimetypes.add_type("audio/m4a", ".m4a")
+
 import db
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Request, Form


### PR DESCRIPTION
## Summary
- recognize `.m4a` files with audio/m4a MIME type
- add regression test ensuring `call_whisper` sends audio/m4a

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684582fb3fbc832abcfc81aaec0a8bd1