### PR TITLE
Enhance chunking and error output

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -136,6 +136,7 @@
 
     async function getChunkSize(file) {
       const CHUNK_SECONDS = 600; // 10 minutes
+      const MAX_BYTES = 25 * 1024 * 1024; // 25MB limit
       return new Promise((resolve) => {
         const audio = new Audio();
         audio.preload = 'metadata';
@@ -143,12 +144,12 @@
         audio.onloadedmetadata = () => {
           const bytesPerSecond = file.size / audio.duration;
           URL.revokeObjectURL(audio.src);
-          resolve(bytesPerSecond * CHUNK_SECONDS);
+          resolve(Math.min(MAX_BYTES, bytesPerSecond * CHUNK_SECONDS));
         };
         audio.onerror = () => {
           URL.revokeObjectURL(audio.src);
-          // Fallback to 24MB if duration can't be determined
-          resolve(24 * 1024 * 1024);
+          // Fallback to 25MB if duration can't be determined
+          resolve(MAX_BYTES);
         };
       });
     }
@@ -205,9 +206,20 @@
         formData.append('file', chunk, file.name);
 
         const url = lang ? '/transcribe?language=' + encodeURIComponent(lang) : '/transcribe';
-        const response = await fetch(url, { method: 'POST', body: formData });
+        let response;
+        try {
+          response = await fetch(url, { method: 'POST', body: formData });
+        } catch (err) {
+          resultPre.textContent = translations[currentLang].error + err.message;
+          return;
+        }
         if (!response.ok) {
-          resultPre.textContent = translations[currentLang].error + response.status;
+          let message = response.status.toString();
+          try {
+            const errData = await response.json();
+            if (errData.detail) message += ' - ' + errData.detail;
+          } catch (e) {}
+          resultPre.textContent = translations[currentLang].error + message;
           return;
         }
 


### PR DESCRIPTION
## Summary
- limit client-side chunk size to 25MB even when audio duration is known
- display detailed error messages from the backend in the web UI
- surface Whisper API HTTP error details in the backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a39478ca0832a8dbba2a93d8114ff