### PR TITLE
Handle m4a chunks correctly

### DIFF
--- a/main.py
+++ b/main.py
@@ -275,9 +275,18 @@ async def transcribe(
     logger.debug("Received %s (%d bytes)", file.filename, len(data))
 
     ext = os.path.splitext(file.filename or "")[1].lower()
-    sniffed = sniff_extension(data) or ext
+    sniffed_ext = sniff_extension(data)
+    sniffed = sniffed_ext or ext
 
-    if sniffed in (".mp3", ".m4a"):
+    if sniffed_ext is None and ext in (".m4a", ".mp4"):
+        # Chunk of an MP4/M4A file - convert to MP3 because the container is invalid
+        try:
+            data = convert_to_mp3(data, ext)
+            file.filename = os.path.splitext(file.filename or "audio")[0] + ".mp3"
+            sniffed = ".mp3"
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
+    elif sniffed in (".mp3", ".m4a"):
         # Use the sniffed extension if it differs from the provided one
         file.filename = os.path.splitext(file.filename or "audio")[0] + sniffed
         if sniffed == ".m4a":


### PR DESCRIPTION
## Summary
- convert m4a/mp4 chunks to mp3 if they have no header
- add regression test for chunk conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5f955700832a93ca367fe1b8ccb2