### PR TITLE
Refine audio handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,15 +278,7 @@ async def transcribe(
     sniffed_ext = sniff_extension(data)
     sniffed = sniffed_ext or ext
 
-    if sniffed_ext is None and ext in (".m4a", ".mp4"):
-        # Chunk of an MP4/M4A file - convert to MP3 because the container is invalid
-        try:
-            data = convert_to_mp3(data, ext)
-            file.filename = os.path.splitext(file.filename or "audio")[0] + ".mp3"
-            sniffed = ".mp3"
-        except Exception as exc:
-            raise HTTPException(status_code=500, detail=str(exc))
-    elif sniffed in (".mp3", ".m4a"):
+    if sniffed in (".mp3", ".m4a"):
         # Use the sniffed extension if it differs from the provided one
         file.filename = os.path.splitext(file.filename or "audio")[0] + sniffed
         if sniffed == ".m4a":

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -200,7 +200,7 @@ def test_m4a_chunk_conversion(monkeypatch):
 
     def fake_fix(data):
         called['fix'] = True
-        return data
+        return b'fixed'
 
     monkeypatch.setattr(main, 'convert_to_mp3', fake_convert_to_mp3)
     monkeypatch.setattr(main, 'call_whisper', fake_call_whisper)
@@ -211,7 +211,7 @@ def test_m4a_chunk_conversion(monkeypatch):
     response = client.post('/transcribe', files=files)
 
     assert response.status_code == 200
-    assert called.get('convert') == '.m4a'
-    assert called['data'] == b'mp3data'
-    assert called['filename'].endswith('.mp3')
-    assert 'fix' not in called
+    assert 'convert' not in called
+    assert called.get('fix')
+    assert called['data'] == b'fixed'
+    assert called['filename'].endswith('.m4a')


### PR DESCRIPTION
## Summary
- avoid converting m4a files to mp3
- adjust test for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a61a3d7a0832a8d91da660c1d66b5